### PR TITLE
change cms git branch from develop to main

### DIFF
--- a/netlifycms/config.yml
+++ b/netlifycms/config.yml
@@ -6,13 +6,8 @@ local_backend: true
 
 backend:
   name: git-gateway
-  branch: develop
+  branch: main
 
-
-
-
-  #repo: Platoniq/wilder-journal
-  #branch: main
 i18n:
   default_locale: es
 ---


### PR DESCRIPTION
I saw that you have changed the deploy branch in netlify from develop to main, therefore the edits in the CMS are no longer being deployed.

I believe that by changing this we will write directly to the `main` branch instead of develop and continue being able to publish.

Thanks <3